### PR TITLE
Change import paths to relative

### DIFF
--- a/src/HatsEligibilityModule.sol
+++ b/src/HatsEligibilityModule.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.18;
 
 // import { console2 } from "forge-std/Test.sol"; // remove before deploy
-import { HatsModule } from "src/HatsModule.sol";
+import { HatsModule } from "./HatsModule.sol";
 import { IHatsEligibility } from "hats-protocol/Interfaces/IHatsEligibility.sol";
 
 abstract contract HatsEligibilityModule is HatsModule, IHatsEligibility {

--- a/src/HatsModule.sol
+++ b/src/HatsModule.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.18;
 
 // import { console2 } from "forge-std/Test.sol"; // remove before deploy
 import { IHats } from "hats-protocol/Interfaces/IHats.sol";
-import { IHatsModule } from "src/interfaces/IHatsModule.sol";
+import { IHatsModule } from "./interfaces/IHatsModule.sol";
 import { Clone } from "solady/utils/Clone.sol";
 import { Initializable } from "@openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
 

--- a/src/HatsModuleFactory.sol
+++ b/src/HatsModuleFactory.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.18;
 
 // import { console2 } from "forge-std/Test.sol"; // remove before deploy
-import { HatsModule } from "src/HatsModule.sol";
+import { HatsModule } from "./HatsModule.sol";
 import { LibClone } from "solady/utils/LibClone.sol";
 import { IHats } from "hats-protocol/Interfaces/IHats.sol";
 

--- a/src/HatsToggleModule.sol
+++ b/src/HatsToggleModule.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.18;
 
 // import { console2 } from "forge-std/Test.sol"; // remove before deploy
-import { HatsModule } from "src/HatsModule.sol";
+import { HatsModule } from "./HatsModule.sol";
 import { IHatsToggle } from "hats-protocol/Interfaces/IHatsToggle.sol";
 
 abstract contract HatsToggleModule is HatsModule, IHatsToggle {

--- a/src/utils/DeployFunctions.sol
+++ b/src/utils/DeployFunctions.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.18;
 
 import { console2 } from "forge-std/Test.sol";
-import { HatsModule, HatsModuleFactory, IHats } from "src/HatsModuleFactory.sol";
+import { HatsModule, HatsModuleFactory, IHats } from "../HatsModuleFactory.sol";
 
 function deployModuleFactory(IHats _hats, bytes32 _salt, string memory _version) returns (HatsModuleFactory _factory) {
   _factory = new HatsModuleFactory{ salt: _salt}(_hats, _version);


### PR DESCRIPTION
Using absolute import paths causes some problems to verify the contracts on Etherscan:
https://book.getfoundry.sh/forge/deploying#verifying-contracts-with-ambiguous-import-paths
Couldn't verify the Jokerace eligibility module... changing to relative paths fixed that

