### PR TITLE
add saltNonce to Factory

### DIFF
--- a/script/HatsEligibilitiesChain.s.sol
+++ b/script/HatsEligibilitiesChain.s.sol
@@ -24,7 +24,7 @@ contract DeployImplementation is Script {
     address deployer = vm.rememberKey(privKey);
     vm.startBroadcast(deployer);
 
-    implementation = new HatsEligibilitiesChain{ salt: SALT}(version);
+    implementation = new HatsEligibilitiesChain{ salt: SALT }(version);
 
     vm.stopBroadcast();
 

--- a/script/HatsTogglesChain.s.sol
+++ b/script/HatsTogglesChain.s.sol
@@ -24,7 +24,7 @@ contract DeployImplementation is Script {
     address deployer = vm.rememberKey(privKey);
     vm.startBroadcast(deployer);
 
-    implementation = new HatsTogglesChain{ salt: SALT}(version);
+    implementation = new HatsTogglesChain{ salt: SALT }(version);
 
     vm.stopBroadcast();
 

--- a/src/utils/DeployFunctions.sol
+++ b/src/utils/DeployFunctions.sol
@@ -5,7 +5,7 @@ import { console2 } from "forge-std/Test.sol";
 import { HatsModule, HatsModuleFactory, IHats } from "../HatsModuleFactory.sol";
 
 function deployModuleFactory(IHats _hats, bytes32 _salt, string memory _version) returns (HatsModuleFactory _factory) {
-  _factory = new HatsModuleFactory{ salt: _salt}(_hats, _version);
+  _factory = new HatsModuleFactory{ salt: _salt }(_hats, _version);
 }
 
 function deployModuleInstance(
@@ -13,7 +13,8 @@ function deployModuleInstance(
   address _implementation,
   uint256 _hatId,
   bytes memory _otherImmutableArgs,
-  bytes memory _initData
+  bytes memory _initData,
+  uint256 _saltNonce
 ) returns (address _instance) {
-  _instance = _factory.createHatsModule(_implementation, _hatId, _otherImmutableArgs, _initData);
+  _instance = _factory.createHatsModule(_implementation, _hatId, _otherImmutableArgs, _initData, _saltNonce);
 }

--- a/test/HatsEligibilitiesChain.t.sol
+++ b/test/HatsEligibilitiesChain.t.sol
@@ -34,6 +34,8 @@ contract DeployImplementationTest is DeployImplementation, Test {
 
   address[] expectedModules;
 
+  uint256 saltNonce = 1;
+
   function deployInstanceTwoModules(
     uint256 targetHat,
     uint256 numClauses,
@@ -43,8 +45,9 @@ contract DeployImplementationTest is DeployImplementation, Test {
   ) public returns (HatsEligibilitiesChain) {
     bytes memory otherImmutableArgs = abi.encodePacked(numClauses, lengths, _module1, _module2);
     // deploy the instance
-    return
-      HatsEligibilitiesChain(deployModuleInstance(FACTORY, address(implementation), targetHat, otherImmutableArgs, ""));
+    return HatsEligibilitiesChain(
+      deployModuleInstance(FACTORY, address(implementation), targetHat, otherImmutableArgs, "", saltNonce)
+    );
   }
 
   function deployInstanceThreeModules(
@@ -57,8 +60,9 @@ contract DeployImplementationTest is DeployImplementation, Test {
   ) public returns (HatsEligibilitiesChain) {
     bytes memory otherImmutableArgs = abi.encodePacked(numClauses, lengths, _module1, _module2, _module3);
     // deploy the instance
-    return
-      HatsEligibilitiesChain(deployModuleInstance(FACTORY, address(implementation), targetHat, otherImmutableArgs, ""));
+    return HatsEligibilitiesChain(
+      deployModuleInstance(FACTORY, address(implementation), targetHat, otherImmutableArgs, "", saltNonce)
+    );
   }
 
   function setUp() public virtual {

--- a/test/HatsModule.t.sol
+++ b/test/HatsModule.t.sol
@@ -59,16 +59,21 @@ contract DeployInstance is HatsModuleTest {
     // expect event emitted with the initData
     vm.expectEmit(true, true, true, true);
     emit HatsModuleFactory_ModuleDeployed(
-      address(impl), factory.getHatsModuleAddress(address(impl), hatId, otherArgs), hatId, otherArgs, initData
+      address(impl),
+      factory.getHatsModuleAddress(address(impl), hatId, otherArgs, saltNonce),
+      hatId,
+      otherArgs,
+      initData,
+      saltNonce
     );
     // deploy an instance of HatsModuleHarness via the factory
     // inst = HatsModuleHarness(factory.createHatsModule(address(impl), hatId, otherArgs, initData));
-    inst = HatsModuleHarness(deployModuleInstance(factory, address(impl), hatId, otherArgs, initData));
+    inst = HatsModuleHarness(deployModuleInstance(factory, address(impl), hatId, otherArgs, initData, saltNonce));
   }
 
   function test_immutables() public {
     // deploy an instance of HatsModuleHarness via the factory
-    inst = HatsModuleHarness(deployModuleInstance(factory, address(impl), hatId, otherArgs, initData));
+    inst = HatsModuleHarness(deployModuleInstance(factory, address(impl), hatId, otherArgs, initData, saltNonce));
 
     assertEq(address(inst.IMPLEMENTATION()), address(impl), "incorrect implementation address");
     assertEq(address(inst.HATS()), address(hats), "incorrect hats address");
@@ -78,14 +83,14 @@ contract DeployInstance is HatsModuleTest {
 
   function test_version() public {
     // deploy an instance of HatsModuleHarness via the factory
-    inst = HatsModuleHarness(deployModuleInstance(factory, address(impl), hatId, otherArgs, initData));
+    inst = HatsModuleHarness(deployModuleInstance(factory, address(impl), hatId, otherArgs, initData, saltNonce));
 
     assertEq(inst.version(), MODULE_VERSION, "incorrect module version");
   }
 
   function test_setUp_cannotBeCalledTwice() public {
     // deploy an instance of HatsModuleHarness via the factory
-    inst = HatsModuleHarness(deployModuleInstance(factory, address(impl), hatId, otherArgs, initData));
+    inst = HatsModuleHarness(deployModuleInstance(factory, address(impl), hatId, otherArgs, initData, saltNonce));
 
     // expect revert if setUp is called again
     vm.expectRevert();
@@ -97,6 +102,6 @@ contract DeployInstance is HatsModuleTest {
     vm.expectEmit(true, true, true, true);
     emit HatsModuleHarness_SetUp(initData);
     // deploy an instance of HatsModuleHarness via the factory
-    inst = HatsModuleHarness(deployModuleInstance(factory, address(impl), hatId, otherArgs, initData));
+    inst = HatsModuleHarness(deployModuleInstance(factory, address(impl), hatId, otherArgs, initData, saltNonce));
   }
 }

--- a/test/HatsTogglesChain.t.sol
+++ b/test/HatsTogglesChain.t.sol
@@ -30,6 +30,8 @@ contract DeployImplementationTest is DeployImplementation, Test {
 
   address[] expectedModules;
 
+  uint256 saltNonce = 1;
+
   function deployInstanceTwoModules(
     uint256 targetHat,
     uint256 numClauses,
@@ -39,7 +41,9 @@ contract DeployImplementationTest is DeployImplementation, Test {
   ) public returns (HatsTogglesChain) {
     bytes memory otherImmutableArgs = abi.encodePacked(numClauses, lengths, _module1, _module2);
     // deploy the instance
-    return HatsTogglesChain(deployModuleInstance(FACTORY, address(implementation), targetHat, otherImmutableArgs, ""));
+    return HatsTogglesChain(
+      deployModuleInstance(FACTORY, address(implementation), targetHat, otherImmutableArgs, "", saltNonce)
+    );
   }
 
   function deployInstanceThreeModules(
@@ -52,7 +56,9 @@ contract DeployImplementationTest is DeployImplementation, Test {
   ) public returns (HatsTogglesChain) {
     bytes memory otherImmutableArgs = abi.encodePacked(numClauses, lengths, _module1, _module2, _module3);
     // deploy the instance
-    return HatsTogglesChain(deployModuleInstance(FACTORY, address(implementation), targetHat, otherImmutableArgs, ""));
+    return HatsTogglesChain(
+      deployModuleInstance(FACTORY, address(implementation), targetHat, otherImmutableArgs, "", saltNonce)
+    );
   }
 
   function setUp() public virtual {


### PR DESCRIPTION
This PR adds a `saltNonce` parameter to module deployment with the intention of enabling modules to be redeployed if necessary.

The only change is to the HatsModuleFactory, which is fully backwards compatible with existing module implementations and instances. HatsModule does not change, and there is no impact on what module developers need to do or know.

There will be downstream impact on the [Modules SDK](https://github.com/Hats-Protocol/modules-sdk) and (optionally) apps or Hats clients that use the SDK.

See [this forum post](https://forum.hatsprotocol.xyz/t/enabling-modules-to-be-redeployed-in-case-of-incorrect-configuration-by-hatsmodulesfactory/74) for additional context.